### PR TITLE
Use correct error variable name

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ class MapTileDownloader {
       this.area = this.checkArea(data);
       this.status = true;
     } catch (err) {
-      console.error('Error :', error.message);
+      console.error('Error :', err.message);
     }
   }
 


### PR DESCRIPTION
Fixes `ReferenceError: error is not defined` when there is a problem with the input data.